### PR TITLE
Update AzureOpenAI to pass api_key, api_version, and azure_endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ See [the documentation](https://docs.github.com/en/actions/writing-workflows/cho
 - **Default**: `""` (empty)
 - **Usage**: Provide the Azure OpenAI endpoint if you want to use Azure's OpenAI service.
 
+#### 1.3.7. `api_key`
+
+- **Description**: The API key for Azure OpenAI.
+- **Default**: `""` (empty)
+- **Usage**: Provide the API key for Azure OpenAI if you want to use Azure's OpenAI service.
+
+#### 1.3.8. `api_version`
+
+- **Description**: The API version for Azure OpenAI.
+- **Default**: `""` (empty)
+- **Usage**: Provide the API version for Azure OpenAI if you want to use Azure's OpenAI service.
+
 ## 2. How it works
 
 ### 2.1. files

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,14 @@ inputs:
     description: 'Azure OpenAI Endpoint'
     required: true
     default: ''
+  api_key:
+    description: 'API Key for Azure OpenAI'
+    required: true
+    default: ''
+  api_version:
+    description: 'API Version for Azure OpenAI'
+    required: true
+    default: ''
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -58,3 +66,5 @@ runs:
     LANGUAGE: ${{ inputs.language }}
     CUSTOM_PROMPT: ${{ inputs.custom_prompt }}
     AZURE_OPENAI_ENDPOINT: ${{ inputs.azure_openai_endpoint }}
+    API_KEY: ${{ inputs.api_key }}
+    API_VERSION: ${{ inputs.api_version }}

--- a/src/clients/openai_client.py
+++ b/src/clients/openai_client.py
@@ -14,9 +14,9 @@ class AzureOpenAIClient:
     A client for interacting with the Azure OpenAI API to generate responses using a specified model.
     """
 
-    def __init__(self, model, temperature, max_tokens, api_version, azure_endpoint):
+    def __init__(self, model, temperature, max_tokens, api_version, azure_endpoint, api_key):
         """
-        Initialize the AzureOpenAIClient with model, temperature, max tokens, api_version, and azure_endpoint.
+        Initialize the AzureOpenAIClient with model, temperature, max tokens, api_version, azure_endpoint, and api_key.
 
         Args:
             model (str): The Azure OpenAI model to use.
@@ -24,22 +24,25 @@ class AzureOpenAIClient:
             max_tokens (int): The maximum number of tokens to generate.
             api_version (str): The API version to use.
             azure_endpoint (str): The Azure OpenAI endpoint.
+            api_key (str): The API key for authentication.
         """
         try:
-            self.client = AzureOpenAI(api_version=api_version, azure_endpoint=azure_endpoint)
+            self.client = AzureOpenAI(api_version=api_version, azure_endpoint=azure_endpoint, api_key=api_key)
             self.model = model
             self.temperature = temperature
             self.max_tokens = max_tokens
             self.api_version = api_version
             self.azure_endpoint = azure_endpoint
+            self.api_key = api_key
             logging.info(
                 "Azure OpenAI client initialized successfully, "
-                "Model: %s, temperature: %s, max tokens: %s, API version: %s, Azure endpoint: %s",
+                "Model: %s, temperature: %s, max tokens: %s, API version: %s, Azure endpoint: %s, API key: %s",
                 self.model,
                 self.temperature,
                 self.max_tokens,
                 self.api_version,
-                self.azure_endpoint
+                self.azure_endpoint,
+                self.api_key
             )
         except Exception as e:
             logging.error("Error initializing Azure OpenAI client: %s", e)
@@ -69,7 +72,8 @@ class AzureOpenAIClient:
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
                 api_version=self.api_version,
-                azure_endpoint=self.azure_endpoint
+                azure_endpoint=self.azure_endpoint,
+                api_key=self.api_key
             )
             logging.info("Response generated successfully.")
             return response.choices[0].message.content

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,8 @@ def main():
                                  env_vars['OPENAI_TEMPERATURE'],
                                  env_vars['OPENAI_MAX_TOKENS'],
                                  "2024-08-01-preview",
-                                 env_vars.get('AZURE_OPENAI_ENDPOINT'))
+                                 env_vars.get('AZURE_OPENAI_ENDPOINT'),
+                                 env_vars['API_KEY'])
 
     language = env_vars.get('LANGUAGE', 'en')
     custom_prompt = env_vars.get('CUSTOM_PROMPT')
@@ -67,7 +68,8 @@ def get_env_vars():
         'MODE': (str, True),
         'LANGUAGE': (str, True),
         'CUSTOM_PROMPT': (str, False),
-        'AZURE_OPENAI_ENDPOINT': (str, False)
+        'AZURE_OPENAI_ENDPOINT': (str, False),
+        'API_KEY': (str, True)
     }
 
     env_vars = {}


### PR DESCRIPTION
Update the AzureOpenAIClient to include api_key, api_version, and azure_endpoint.

* **src/clients/openai_client.py**
  - Add `api_key` parameter to `AzureOpenAIClient` constructor.
  - Initialize `AzureOpenAI` with `api_key` in `__init__` method.
  - Update logging to include `api_key`.

* **action.yml**
  - Add `api_key` and `api_version` inputs.
  - Update `env` section to include `api_key` and `api_version`.

* **src/main.py**
  - Update `AzureOpenAIClient` initialization to include `api_key`.
  - Add `API_KEY` to the list of required environment variables.

* **README.md**
  - Add instructions for `api_key` and `api_version` in AzureOpenAI setup.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/o-abdalqader/genai-code-review/pull/3?shareId=5d7af143-fb98-4fe6-82be-19a7a70e1cef).